### PR TITLE
Get optical flow with TV-L1 algorithm

### DIFF
--- a/get_optical_flow.py
+++ b/get_optical_flow.py
@@ -1,10 +1,30 @@
 import numpy as np
-
+import cv2
 
 def get_flow(segment_filepath: str):
-    # TODO: Get the optical flow using OpenCV
+    # Get the optical flow using OpenCV
     # https://opencv-python-tutroals.readthedocs.io/en/latest/py_tutorials/py_video/py_lucas_kanade/py_lucas_kanade.html
 
     # flow.shape (2, frame_count, height, width)
     # flow[0] is dx, flow[1] is dy
-    return flow
+    # Use TV-L1 algorithm instead, since it is used in mlb-youtube dataset
+    # https://www.ipol.im/pub/art/2013/26/article.pdf
+
+    cap = cv2.VideoCapture(segment_filepath)
+    length = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
+    _, frame1 = cap.read()
+    prvf = cv2.cvtColor(frame1, cv2.COLOR_BGR2GRAY)
+    flow_video = []
+    for i in range(length - 1):
+        success, frame2 = cap.read()
+        nextf = cv2.cvtColor(frame2, cv2.COLOR_BGR2GRAY)
+        if not success:
+            break
+        optical_flow = cv2.optflow.createOptFlow_DualTVL1()
+        flow_frame = optical_flow.calc(prvf, nextf, None)
+        # flow_frame = cv2.calcOpticalFlowFarneback(prvf,nextf, None, 0.5, 3, 15, 3, 5, 1.2, 0)
+        flow_video.append(flow_frame)
+        prvf = nextf
+    cap.release()
+    flow_video = np.array(flow_video)
+    return flow_video.transpose(3, 0, 1, 2)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 moviepy == 1.0.0
 scikit-video
+opencv-python == 4.*
+opencv-contrib-python


### PR DESCRIPTION
Implemented `get_flow` function. Instead of Gunner Farneback’s algorithm, which is used in [the sample code](https://opencv-python-tutroals.readthedocs.io/en/latest/py_tutorials/py_video/py_lucas_kanade/py_lucas_kanade.html), TV-L1 algorithm is used to calculate a dense optical-flow, since this algorithm is used for mlb-youtube.  
The problem is that TV-L1 is extremely slow. It takes more than **400** sec to process a video with 150 frames, while Farneback’s algorithm is finished in **20** sec.
However, an optical-flow with TV-L1 looks a lot nicer.

- TV-L1
[![TV-L1](https://i.gyazo.com/4e244d28392c5e69aecd97d07e9d1ef7.gif)](https://gyazo.com/4e244d28392c5e69aecd97d07e9d1ef7)
- Farneback
[![Farneback](https://i.gyazo.com/9e8ebca29e339a74290017878c5f9066.gif)](https://gyazo.com/9e8ebca29e339a74290017878c5f9066)

Which one do you think we should use? There are several hyperparameters for TV-L1, so the time might be reduced by changing them.